### PR TITLE
Adding in a deployment target for macOS

### DIFF
--- a/WiremockClient.podspec
+++ b/WiremockClient.podspec
@@ -13,6 +13,7 @@ WiremockClient is an HTTP client that allows users to interact with a standalone
   s.source           = { :git => 'https://github.com/mobileforming/WiremockClient.git', :tag => '1.1.2' }
 
   s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
 
   s.source_files = 'WiremockClient/Classes/**/*'
 end


### PR DESCRIPTION
I started looking at WiremockClient for a macOS project and adding the osx deployment target was all that was needed to make pod install happy.