### PR TITLE
Additional request api compatibilty

### DIFF
--- a/Sources/WiremockClient/WiremockClient.swift
+++ b/Sources/WiremockClient/WiremockClient.swift
@@ -180,6 +180,7 @@ extension WiremockClient {
         return returnRequests
     }
 
+    /// Deletes all requests that have been recorded to this point
     public static func deleteAllRequests() {
         serverCommand(urlCommand: "__admin/requests",
                       method: .DELETE,

--- a/Sources/WiremockClient/WiremockClient.swift
+++ b/Sources/WiremockClient/WiremockClient.swift
@@ -83,9 +83,13 @@ public struct WiremockClient {
     /// MARK: Private methods
     
     private static func postCommandToServer(urlCommand: String, errorMessagePrefix: String) {
+        serverCommand(urlCommand: urlCommand, method: .POST, errorMessagePrefix: errorMessagePrefix)
+    }
+
+    private static func serverCommand(urlCommand: String, method: RequestMethod, errorMessagePrefix: String) {
         guard let url = URL(string: "\(baseURL)/\(urlCommand)") else { return }
         var request = URLRequest(url: url)
-        request.httpMethod = RequestMethod.POST.rawValue
+        request.httpMethod = method.rawValue
         makeSynchronousRequest(request: request, errorMessagePrefix: errorMessagePrefix)
     }
     
@@ -177,10 +181,9 @@ extension WiremockClient {
     }
 
     public static func deleteAllRequests() {
-        guard let url = URL(string: "\(baseURL)/__admin/requests") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = RequestMethod.DELETE.rawValue
-        makeSynchronousRequest(request: request, errorMessagePrefix: "Error attempting to delete all requests")
+        serverCommand(urlCommand: "__admin/requests",
+                      method: .DELETE,
+                      errorMessagePrefix: "Error attempting to delete all requests")
     }
 
 }

--- a/Sources/WiremockClient/WiremockClient.swift
+++ b/Sources/WiremockClient/WiremockClient.swift
@@ -176,7 +176,7 @@ extension WiremockClient {
         return returnRequests
     }
 
-    public static func deleteRequests(requestMapping: RequestMapping) {
+    public static func deleteAllRequests() {
         guard let url = URL(string: "\(baseURL)/__admin/requests") else { return }
         var request = URLRequest(url: url)
         request.httpMethod = RequestMethod.DELETE.rawValue


### PR DESCRIPTION
We ran into an issue where we wanted to clear out the request history in between verify calls, so I added a deleteAllRequests method and did a little refactoring. Let me know what you think!