### PR TITLE
Publicize StubMapping properties

### DIFF
--- a/Sources/WiremockClient/Stubbing/RequestMapping.swift
+++ b/Sources/WiremockClient/Stubbing/RequestMapping.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An object used to configure a Wiremock request verification mapping. Refer to http://http://wiremock.org/docs/verifying/ for more details.
 public class RequestMapping {
     
-    private var request: RequestPattern
+    private(set) var request: RequestPattern
     
     private init(requestMethod: RequestMethod, urlMatchCondition: URLMatchCondition, url: String) {
         self.request = RequestPattern(requestMethod: requestMethod, urlMatchCondition: urlMatchCondition, url: url)

--- a/Sources/WiremockClient/Stubbing/StubMapping.swift
+++ b/Sources/WiremockClient/Stubbing/StubMapping.swift
@@ -10,14 +10,14 @@ import Foundation
 
 /// An object used to configure a Wiremock server stub mapping. Refer to http://wiremock.org/docs/stubbing/ and http://wiremock.org/docs/request-matching/ for more details.
 public class StubMapping {
-    private var request: RequestMapping
-    private var response: ResponseDefinition?
-    private var uuid: UUID
-    private var name: String?
-    private var priority: Int?
-    private var scenarioName: String?
-    private var requiredScenarioState: String?
-    private var newScenarioState: String?
+    private(set) var request: RequestMapping
+    private(set) var response: ResponseDefinition?
+    private(set) var uuid: UUID
+    private(set) var name: String?
+    private(set) var priority: Int?
+    private(set) var scenarioName: String?
+    private(set) var requiredScenarioState: String?
+    private(set) var newScenarioState: String?
     
     private init(requestMethod: RequestMethod, urlMatchCondition: URLMatchCondition, url: String) {
         self.request = RequestMapping.requestFor(requestMethod: requestMethod, urlMatchCondition: urlMatchCondition, url: url)


### PR DESCRIPTION
Sometimes we might be interested in the status of a given stub mapping object. For example, we may want to print logs for an array of stubs. We might also want to do some check before performing some operator on the given stub. Either way, we need the properties to be public.