### PR TITLE
Update Swift version and README for SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -8,11 +8,18 @@ WiremockClient is an HTTP client that allows users to interact with a standalone
 
 ## Installation
 
-WiremockClient is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+WiremockClient is available through [CocoaPods](http://cocoapods.org) and [Swift Package Manager](https://swift.org/package-manager/).
+
+To install with CocoaPods, simply add the following line to your Podfile:
 
 ```ruby
 pod "WiremockClient"
+```
+
+To install with SwiftPM, add the following line to the `dependencies` section of your Package.swift:
+
+```swift
+.package(url: "https://github.com/mobileforming/WiremockClient", .upToNextMajor(from: Version(major: 2, minor: 2, patch: 0)))
 ```
 
 ## Usage


### PR DESCRIPTION
This updates the package manifest to Swift 5.0, which resolves a compiler issue around double optionals from `try?` and adds SPM instructions in the README.