### PR TITLE
Add stub mapping method to stub from json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ WiremockClient.postMapping(stubMapping:
 )
 ```
 
+WiremockClient also includes a convenience method for stubbing request JSON that is stored in a local file:
+
+```swift
+WiremockClient.postMapping(stubMapping:
+    StubMapping.stubFor(requestMethod: .ANY, urlMatchCondition: .urlEqualTo, url: "http://localhost:8080/my/path")
+        .withRequestBodyFromLocalJsonFile(fileName: "myFile", in: Bundle(for: type(of: self)))
+        .willReturn(ResponseDefinition())
+)
+```
+
 Mappings can also be prioritized as described in the ‘Stub priority’ section of the [Stubbing](http://wiremock.org/docs/stubbing/) documentation:
 
 ```swift

--- a/Sources/WiremockClient/Stubbing/StubMapping.swift
+++ b/Sources/WiremockClient/Stubbing/StubMapping.swift
@@ -186,7 +186,7 @@ public class StubMapping {
             }
             _ = self.withRequestBodyEqualToJson(jsonString: jsonString, ignoreArrayOrder: ignoreArayOrder, ignoreExtraElements: ignoreExtraElements)
         } catch {
-            print("Error adding body to ResponseDefinition from file \(fileName): \(error.localizedDescription)")
+            print("Error adding body to StubMapping from file \(fileName): \(error.localizedDescription)")
         }
         return self
     }

--- a/Tests/WiremockClientTests/StubMappingTests.swift
+++ b/Tests/WiremockClientTests/StubMappingTests.swift
@@ -142,6 +142,18 @@ class StubMappingTests: XCTestCase {
         let ignoreExtraElements = try XCTUnwrap(bodyPatternDict[RequestMapping.Constants.keyIgnoreExtraElements] as? Bool)
         XCTAssertTrue(ignoreExtraElements)
     }
+
+    func test_withRequestBodyFromLocalJsonFile() throws {
+        let jsonString = "{\"testKey\":\"testValue\"}"
+        let fileName = "test"
+        let mapping = StubMapping.stubFor(requestMethod: .ANY, urlMatchCondition: .urlMatching, url: "")
+            .withRequestBodyFromLocalJsonFile(fileName, in: Bundle(for: type(of: self)), ignoreArayOrder: true, ignoreExtraElements: true)
+        let bodyPatternDict = try XCTUnwrap(mapping.getFirstBodyPattern())
+        let jsonResult = try XCTUnwrap(bodyPatternDict[MatchCondition.equalToJson.rawValue] as? String)
+        XCTAssertEqual(jsonString, jsonResult)
+        let ignoreExtraElements = try XCTUnwrap(bodyPatternDict[RequestMapping.Constants.keyIgnoreExtraElements] as? Bool)
+        XCTAssertTrue(ignoreExtraElements)
+    }
 }
 
 private extension StubMapping {


### PR DESCRIPTION
This PR introduces a new method in the `StubMapping` class to allow stubbing request methods from a local JSON file similar to how the `ResponseDefinition.withLocalJsonBodyFile` works.